### PR TITLE
ROCANA-3308: Write a median UDAF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+CMakeCache.txt
+CMakeFiles/**
+Makefile
+cmake_install.cmake
+build/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright 2015 Rocana, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 2.6)
+
+# where to put generated libraries
+set(LIBRARY_OUTPUT_PATH "build")
+# where to put generated binaries
+set(EXECUTABLE_OUTPUT_PATH "build")
+
+find_program(CLANG_EXECUTABLE clang++)
+
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -ggdb")
+
+# Function to generate rule to cross compile a source file to an IR module.
+# This should be called with the .cc src file and it will generate a
+# src-file-ir target that can be built.
+# e.g. COMPILE_TO_IR(test.cc) generates the "test-ir" make target.
+set(IR_COMPILE_FLAGS "-emit-llvm" "-O3" "-c")
+function(COMPILE_TO_IR SRC_FILE)
+  get_filename_component(BASE_NAME ${SRC_FILE} NAME_WE)
+  set(OUTPUT_FILE "build/${BASE_NAME}.ll")
+  add_custom_command(
+    OUTPUT ${OUTPUT_FILE}
+    COMMAND ${CLANG_EXECUTABLE} ${IR_COMPILE_FLAGS} ${SRC_FILE} -o ${OUTPUT_FILE}
+    DEPENDS ${SRC_FILE})
+  add_custom_target(${BASE_NAME}-ir ALL DEPENDS ${OUTPUT_FILE})
+endfunction(COMPILE_TO_IR)
+
+# Build the UDA/UDFs into a shared library.
+add_library(rocana-udfs SHARED median.cc)
+
+# Custom targest to cross compile UDA/UDF to ir
+if (CLANG_EXECUTABLE)
+  COMPILE_TO_IR(median.cc)
+endif(CLANG_EXECUTABLE)
+
+# This is an example of how to use the test harness to help develop UDF and UDAs.
+target_link_libraries(rocana-udfs ImpalaUdf)
+add_executable(rocana-udfs-test median-test.cc)
+target_link_libraries(rocana-udfs-test rocana-udfs)

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+Impala
+
+  Copyright 2012 Cloudera Inc.
+  This product includes software developed by the Impala project (http://impala.io/)
+
+Impala Sample UDFs
+
+  Copyright 2012 Cloudera Inc.
+  This product includes software developed by the Impala sample UDFs project
+  (https://github.com/cloudera/impala-udf-samples)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
 # rocana-impala-udfs
 Various Impala UDFs and UDAFs
+
+## Building, Testing, and Installing
+
+1. Use CMake to generate build files
+ 
+ ```console
+ $ cmake .
+ ```
+2. Build a shared object file
+ 
+ ```console
+ $ make
+ ```
+3. Run unit tests
+ 
+ ```console
+ $ build/rocana-udfs-test
+ ```
+4. Copy shared object file to HDFS
+ 
+ ```console
+ $ sudo -u hdfs hdfs dfs -mkdir /user/impala/udfs
+ $ sudo -u hdfs hdfs dfs -put librocana-udfs.so /user/impala/udfs
+ $ sudo -u hdfs hdfs dfs -chown -R impala:impala /user/impala/udfs
+ ```
+
+## Functions
+### Bounded Median
+
+A port of Impala's APPX_MEDIAN function that accepts a parameter that controls the maximum number of samples.
+
+#### Usage
+These steps assume you've installed the UDFs shared object file as described in Building and Installing above.
+
+1. Create the function
+ 
+ ```sql
+ CREATE AGGREGATE FUNCTION appx_median_bounded(double, int) returns string
+    location '/user/impala/udfs/librocana-udfs.so'
+    init_fn='ReservoirSampleInit'
+    update_fn='ReservoirSampleUpdate'
+    merge_fn='ReservoirSampleMerge'
+    serialize_fn='ReservoirSampleSerialize'
+    finalize_fn='AppxMedianFinalize';
+ ```
+2. Create a test table
+
+ ```sql
+ CREATE TABLE numbers (x DOUBLE);
+ ```
+3. Insert some simple data
+ 
+ ```sql
+ INSERT INTO numbers VALUES (1.1), (2.2), (3.3), (4.4), (5.5);
+ ```
+4. Calculate median of the data
+ 
+ ```sql
+ SELECT CAST(appx_median_bounded(x, 5) AS DOUBLE) FROM numbers;
+ ```

--- a/median-test.cc
+++ b/median-test.cc
@@ -1,0 +1,92 @@
+// Copyright 2015 Rocana, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <math.h>
+
+#include <impala_udf/uda-test-harness.h>
+#include <impala_udf/udf-test-harness.h>
+#include "median.h"
+
+using namespace impala;
+using namespace impala_udf;
+using namespace std;
+
+// For algorithms that work on floating point values, the results might not match
+// exactly due to floating point inprecision. The test harness allows passing a
+// custom equality comparator. Here's an example of one that can tolerate some small
+// error.
+// This is particularly true  for distributed execution since the order the values
+// are processed is variable.
+bool FuzzyCompare(const DoubleVal& x, const DoubleVal& y) {
+  if (x.is_null && y.is_null) return true;
+  if (x.is_null || y.is_null) return false;
+  return fabs(x.val - y.val) < 0.00001;
+}
+
+// Reimplementation of FuzzyCompare that parses doubles encoded as StringVals.
+// TODO: This can be removed when separate intermediate types are supported in Impala 2.0
+bool FuzzyCompareStrings(const StringVal& x, const StringVal& y) {
+  if (x.is_null && y.is_null) return true;
+  if (x.is_null || y.is_null) return false;
+  // Note that atof expects null-terminated strings, which is not guaranteed by
+  // StringVals. However, since our UDAs serialize double to StringVals via stringstream,
+  // we know the serialized StringVals will be null-terminated in this case.
+  double x_val = atof(string(reinterpret_cast<char*>(x.ptr), x.len).c_str());
+  double y_val = atof(string(reinterpret_cast<char*>(y.ptr), y.len).c_str());
+  return fabs(x_val - y_val) < 0.00001;
+}
+
+bool TestMedian() {
+  // Setup the test UDAs.
+  UdaTestHarness2<StringVal, StringVal, DoubleVal, IntVal> median(
+      ReservoirSampleInit, ReservoirSampleUpdate, ReservoirSampleMerge, ReservoirSampleSerialize, AppxMedianFinalize);
+  median.SetResultComparator(FuzzyCompareStrings);
+
+
+  // Test empty input
+  vector<DoubleVal> vals;
+  vector<IntVal> samples;
+  if (!median.Execute(vals, samples, StringVal::null())) {
+    cerr << "Median: " << median.GetErrorMsg() << endl;
+    return false;
+  }
+
+  // Initialize the test values.
+  for (int i = 0; i < 1001; ++i) {
+    vals.push_back(DoubleVal(i));
+    samples.push_back(IntVal(1001));
+  }
+
+  double expected_median = 500;
+  stringstream expected_median_ss;
+  expected_median_ss << expected_median;
+  string expected_median_str = expected_median_ss.str();
+  StringVal expected_median_sv(expected_median_str.c_str());
+
+  // Run the tests
+  if (!median.Execute(vals, samples, expected_median_sv)) {
+    cerr << "Median: " << median.GetErrorMsg() << endl;
+    return false;
+  }
+
+  return true;
+}
+
+int main(int argc, char** argv) {
+  bool passed = true;
+  passed &= TestMedian();
+  cerr << (passed ? "Tests passed." : "Tests failed.") << endl;
+  return 0;
+}

--- a/median.cc
+++ b/median.cc
@@ -1,0 +1,304 @@
+// Copyright 2015 Rocana, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "median.h"
+#include <assert.h>
+#include <sstream>
+
+#include <boost/random/ranlux.hpp>
+#include <boost/random/uniform_int.hpp>
+
+using namespace impala_udf;
+using namespace std;
+
+using boost::ranlux64_3;
+using boost::uniform_int;
+
+// Utility function for serialization to StringVal from Cloudera sample code
+template <typename T>
+StringVal ToStringVal(FunctionContext* context, const T& val) {
+  stringstream ss;
+  ss << val;
+  string str = ss.str();
+  StringVal string_val(context, str.size());
+  memcpy(string_val.ptr, str.c_str(), str.size());
+  return string_val;
+}
+
+template <>
+StringVal ToStringVal<DoubleVal>(FunctionContext* context, const DoubleVal& val) {
+  if (val.is_null) return StringVal::null();
+  return ToStringVal(context, val.val);
+}
+
+// Approximate median based on reservoir sampling. Adapted from Impala's
+// built-in APPX_MEDIAN function. This version takes a second parameter
+// that is the maximum number of samples to cap memory usage.
+// Detailed differences are called out in the comments below.
+const static int MAX_STRING_SAMPLE_LEN = 10;
+
+template <typename T>
+struct ReservoirSample {
+  // Sample value
+  T val;
+  // Key on which the samples are sorted.
+  double key;
+
+  ReservoirSample() : key(-1) { }
+  ReservoirSample(const T& val) : val(val), key(-1) { }
+
+  // Gets a copy of the sample value that allocates memory from ctx, if necessary.
+  T GetValue(FunctionContext* ctx) { return val; }
+};
+
+// Template specialization for StringVal because we do not store the StringVal itself.
+// Instead, we keep fixed size arrays and truncate longer strings if necessary.
+template <>
+struct ReservoirSample<StringVal> {
+  uint8_t val[MAX_STRING_SAMPLE_LEN];
+  int len; // Size of string (up to MAX_STRING_SAMPLE_LEN)
+  double key;
+
+  ReservoirSample() : len(0), key(-1) { }
+
+  ReservoirSample(const StringVal& string_val) : key(-1) {
+    len = min(string_val.len, MAX_STRING_SAMPLE_LEN);
+    memcpy(&val[0], string_val.ptr, len);
+  }
+
+  // Gets a copy of the sample value that allocates memory from ctx, if necessary.
+  StringVal GetValue(FunctionContext* ctx) {
+    StringVal result = StringVal(ctx, len);
+    memcpy(result.ptr, &val[0], len);
+    return result;
+  }
+};
+
+template <typename T>
+struct ReservoirSampleState {
+  // In our fork of this function, the samples are in a dynmaiclly
+  // allocated array rather than statically allocated.
+  ReservoirSample<T>* samples;
+
+  // Maximum number of samples. New to our fork.
+  int max_samples;
+
+  // Number of collected samples.
+  int num_samples;
+
+  // Number of values over which the samples were collected.
+  int64_t source_size;
+
+  // Random number generator for generating 64-bit integers
+  // TODO: Replace with mt19937_64 when upgrading boost
+  ranlux64_3 rng;
+
+  int64_t GetNext64(int64_t max) {
+    uniform_int<int64_t> dist(0, max);
+    return dist(rng);
+  }
+};
+
+int SizeOfState(int max_samples) {
+  return sizeof(ReservoirSampleState<DoubleVal>) + max_samples*sizeof(ReservoirSample<DoubleVal>);
+}
+
+void ReservoirSampleInit(FunctionContext* ctx, StringVal* dst) {
+  // Allocation room for the state with no samples, due to a bug in Impala the
+  // space for samples is allocated in the ReservoirSampleUpdate function
+  int str_len = SizeOfState(0);
+  dst->is_null = false;
+  dst->ptr = ctx->Allocate(str_len);
+  dst->len = str_len;
+  memset(dst->ptr, 0, str_len);
+  *reinterpret_cast<ReservoirSampleState<DoubleVal>*>(dst->ptr) = ReservoirSampleState<DoubleVal>();
+}
+
+void ReservoirSampleUpdate(FunctionContext* ctx, const DoubleVal& src, const IntVal& max_samples,
+    StringVal* dst) {
+  if (src.is_null) return;
+  DCHECK(!dst->is_null);
+  // This error checking is not as precise, but only happens during debug builds anyway
+  DCHECK_GE(dst->len, SizeOfState(0));
+
+  // Reallocate the sapce for samples if there isn't enough space. This will do bad things(tm)
+  // if the second parameter to our function isn't a constant but checking for constant values
+  // isn't working in Impala 2.2
+  if (dst->len < SizeOfState(max_samples.val)) {
+    dst->ptr = ctx->Reallocate(dst->ptr, SizeOfState(max_samples.val));
+    dst->len = SizeOfState(max_samples.val);
+  }
+
+  ReservoirSampleState<DoubleVal>* state = reinterpret_cast<ReservoirSampleState<DoubleVal>*>(dst->ptr);
+  // The samples are stored at the end of the buffer
+  // This differs from the original implementation
+  // where the samples were a statically allocated array
+  state->samples = reinterpret_cast<ReservoirSample<DoubleVal>*>(dst->ptr + sizeof(ReservoirSampleState<DoubleVal>));
+
+  if (state->num_samples < max_samples.val) {
+    state->samples[state->num_samples++] = ReservoirSample<DoubleVal>(src);
+  } else {
+    int64_t r = state->GetNext64(state->source_size);
+    if (r < max_samples.val) state->samples[r] = ReservoirSample<DoubleVal>(src);
+  }
+  ++state->source_size;
+
+  // If the number of max samples has gone up, update the state.
+  // We don't handle the max samples going down.
+  // The max samples *should* be a constant, but this is a hedge against that
+  if (max_samples.val > state->max_samples) {
+    state->max_samples = max_samples.val;
+  }
+}
+
+const StringVal ReservoirSampleSerialize(FunctionContext* ctx,
+    const StringVal& src) {
+  if (src.is_null) return src;
+  StringVal result(ctx, src.len);
+  memcpy(result.ptr, src.ptr, src.len);
+  ctx->Free(src.ptr);
+
+  ReservoirSampleState<DoubleVal>* state = reinterpret_cast<ReservoirSampleState<DoubleVal>*>(result.ptr);
+  // The samples are stored at the end of the buffer
+  state->samples = reinterpret_cast<ReservoirSample<DoubleVal>*>(result.ptr + sizeof(ReservoirSampleState<DoubleVal>));
+
+  // Assign keys to the samples that haven't been set (i.e. if serializing after
+  // Update()). In weighted reservoir sampling the keys are typically assigned as the
+  // sources are being sampled, but this requires maintaining the samples in sorted order
+  // (by key) and it accomplishes the same thing at this point because all data points
+  // coming into Update() get the same weight. When the samples are later merged, they do
+  // have different weights (set here) that are proportional to the source_size, i.e.
+  // samples selected from a larger stream are more likely to end up in the final sample
+  // set. In order to avoid the extra overhead in Update(), we approximate the keys by
+  // picking random numbers in the range [(SOURCE_SIZE - SAMPLE_SIZE)/(SOURCE_SIZE), 1].
+  // This weights the keys by SOURCE_SIZE and implies that the samples picked had the
+  // highest keys, because values not sampled would have keys between 0 and
+  // (SOURCE_SIZE - SAMPLE_SIZE)/(SOURCE_SIZE).
+  for (int i = 0; i < state->num_samples; ++i) {
+    if (state->samples[i].key >= 0) continue;
+    int r = rand() % state->num_samples;
+    state->samples[i].key = ((double) state->source_size - r) / state->source_size;
+  }
+  return result;
+}
+
+template <typename T>
+bool SampleValLess(const ReservoirSample<T>& i, const ReservoirSample<T>& j) {
+  return i.val.val < j.val.val;
+}
+
+template <>
+bool SampleValLess(const ReservoirSample<StringVal>& i,
+    const ReservoirSample<StringVal>& j) {
+  int n = min(i.len, j.len);
+  int result = memcmp(&i.val[0], &j.val[0], n);
+  if (result == 0) return i.len < j.len;
+  return result < 0;
+}
+
+template <>
+bool SampleValLess(const ReservoirSample<DecimalVal>& i,
+    const ReservoirSample<DecimalVal>& j) {
+  return i.val.val16 < j.val.val16;
+}
+
+template <>
+bool SampleValLess(const ReservoirSample<TimestampVal>& i,
+    const ReservoirSample<TimestampVal>& j) {
+  if (i.val.date == j.val.date) return i.val.time_of_day < j.val.time_of_day;
+  else return i.val.date < j.val.date;
+}
+
+template <typename T>
+bool SampleKeyGreater(const ReservoirSample<T>& i, const ReservoirSample<T>& j) {
+  return i.key > j.key;
+}
+
+void ReservoirSampleMerge(FunctionContext* ctx,
+    const StringVal& src_val, StringVal* dst_val) {
+  if (src_val.is_null) return;
+  DCHECK(!dst_val->is_null);
+  DCHECK(!src_val.is_null);
+
+  // This error checking is not as precise, but only happens during debug builds anyway
+  DCHECK_GE(src_val.len, SizeOfState(0));
+  DCHECK_GE(dst_val->len, SizeOfState(0));
+
+  ReservoirSampleState<DoubleVal>* src = reinterpret_cast<ReservoirSampleState<DoubleVal>*>(src_val.ptr);
+  ReservoirSampleState<DoubleVal>* dst = reinterpret_cast<ReservoirSampleState<DoubleVal>*>(dst_val->ptr);
+
+  // Set max_samples based on the MAX(src->max_samples, dst->max_samples)
+  int max_samples = src->max_samples;
+  if (dst->max_samples > max_samples) {
+    max_samples = dst->max_samples;
+  }
+
+  // Only the destination is modifiable, so if it doesn't have enough space for
+  // max_samples, reallocate it
+  if (dst_val->len < SizeOfState(max_samples)) {
+    dst_val->ptr = ctx->Reallocate(dst_val->ptr, SizeOfState(max_samples));
+    dst_val->len = SizeOfState(max_samples);
+    dst = reinterpret_cast<ReservoirSampleState<DoubleVal>*>(dst_val->ptr);
+    dst->max_samples = max_samples;
+  }
+
+  // The samples are stored at the end of the buffer
+  src->samples = reinterpret_cast<ReservoirSample<DoubleVal>*>(src_val.ptr + sizeof(ReservoirSampleState<DoubleVal>));
+  dst->samples = reinterpret_cast<ReservoirSample<DoubleVal>*>(dst_val->ptr + sizeof(ReservoirSampleState<DoubleVal>));
+
+  int src_idx = 0;
+  int src_max = src->num_samples;
+
+  // First, fill up the dst samples if they don't already exist. The samples are now
+  // ordered as a min-heap on the key.
+  while (dst->num_samples < max_samples && src_idx < src_max) {
+    DCHECK_GE(src->samples[src_idx].key, 0);
+    dst->samples[dst->num_samples++] = src->samples[src_idx++];
+    push_heap(dst->samples, dst->samples + dst->num_samples, SampleKeyGreater<DoubleVal>);
+  }
+  // Then for every sample from source, take the sample if the key is greater than
+  // the minimum key in the min-heap.
+  while (src_idx < src_max) {
+    DCHECK_GE(src->samples[src_idx].key, 0);
+    if (src->samples[src_idx].key > dst->samples[0].key) {
+      pop_heap(dst->samples, dst->samples + max_samples, SampleKeyGreater<DoubleVal>);
+      dst->samples[max_samples - 1] = src->samples[src_idx];
+      push_heap(dst->samples, dst->samples + max_samples, SampleKeyGreater<DoubleVal>);
+    }
+    ++src_idx;
+  }
+  dst->source_size += src->source_size;
+}
+
+StringVal AppxMedianFinalize(FunctionContext* ctx,
+    const StringVal& src_val) {
+
+  DCHECK(!src_val.is_null);
+  // This error checking is not as precise, but only happens during debug builds anyway
+  DCHECK_GE(src_val.len, SizeOfState(0));
+
+  ReservoirSampleState<DoubleVal>* src = reinterpret_cast<ReservoirSampleState<DoubleVal>*>(src_val.ptr);
+  // The samples are stored at the end of the buffer
+  src->samples = reinterpret_cast<ReservoirSample<DoubleVal>*>(src_val.ptr + sizeof(ReservoirSampleState<DoubleVal>));
+
+  if (src->num_samples == 0) {
+    ctx->Free(src_val.ptr);
+    return StringVal::null();
+  }
+  sort(src->samples, src->samples + src->num_samples, SampleValLess<DoubleVal>);
+
+  DoubleVal median = src->samples[src->num_samples / 2].GetValue(ctx);
+  ctx->Free(src_val.ptr);
+  return ToStringVal(ctx, median);
+}

--- a/median.h
+++ b/median.h
@@ -1,0 +1,65 @@
+// Copyright 2015 Rocana, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef MEDIAN_H
+#define MEDIAN_H
+
+#include <impala_udf/udf.h>
+
+using namespace impala_udf;
+
+// Utility function for serialization to StringVal from Cloudera sample code
+template <typename T>
+StringVal ToStringVal(FunctionContext* context, const T& val);
+
+// Approximate median based on reservoir sampling. Adapted from Impala's
+// built-in APPX_MEDIAN function. This version takes a second parameter
+// that is the maximum number of samples to cap memory usage.
+
+// Usage: > create aggregate function appx_median_bounded(double, int) returns string
+//          location '/user/impala/udfs/librocana-udfs.so'
+//          init_fn='ReservoirSampleInit'
+//          update_fn='ReservoirSampleUpdate'
+//          merge_fn='ReservoirSampleMerge'
+//          serialize_fn='ReservoirSampleSerialize'
+//          finalize_fn='AppxMedianFinalize';
+//        > select cast(appx_median_bounded(col, 100) as dobule) from tbl;
+//
+//
+
+void ReservoirSampleInit(FunctionContext*, StringVal* slot);
+
+void ReservoirSampleUpdate(FunctionContext*, const DoubleVal& src, const IntVal& max_samples, StringVal* dst);
+
+void ReservoirSampleMerge(FunctionContext*, const StringVal& src, StringVal* dst);
+
+const StringVal ReservoirSampleSerialize(FunctionContext*, const StringVal& src);
+
+StringVal AppxMedianFinalize(FunctionContext*, const StringVal& src);
+
+
+// Logging/debugging utils from RE2.
+// Copyright 2009 The RE2 Authors.  All Rights Reserved.
+
+// Debug-only checking.
+#define DCHECK(condition) assert(condition)
+#define DCHECK_EQ(val1, val2) assert((val1) == (val2))
+#define DCHECK_NE(val1, val2) assert((val1) != (val2))
+#define DCHECK_LE(val1, val2) assert((val1) <= (val2))
+#define DCHECK_LT(val1, val2) assert((val1) < (val2))
+#define DCHECK_GE(val1, val2) assert((val1) >= (val2))
+#define DCHECK_GT(val1, val2) assert((val1) > (val2))
+
+#endif


### PR DESCRIPTION
- Wrote a UDAF for calculating median
- Derived from the built-in appx_median function from Impala
- This port adds a parameter that is the max number of samples to cap
  memory usage.
