### PR TITLE
ROCANA-3705: Create release process for Rocana UDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ CMakeFiles/**
 Makefile
 cmake_install.cmake
 build/**
+target/**

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2015 Rocana
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.rocana</groupId>
+  <artifactId>rocana-impala-udfs</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <os.detection.classifierWithLikes>debian,rhel</os.detection.classifierWithLikes>
+  </properties>
+
+  <build>
+
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.4.0.Final</version>
+      </extension>
+    </extensions>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.7</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+
+          <!-- compile phase - build and install -->
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <target name="cmake-make">
+                <exec executable="cmake" failonerror="true">
+                   <arg value="."/>
+                </exec>
+                <exec executable="make" failonerror="true"/>
+              </target>
+            </configuration>
+          </execution>
+
+          <!-- test phase - execute tests -->
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <target name="rocana-udfs-test" unless="${skipTests}">
+                <exec executable="build/rocana-udfs-test" failonerror="true"/>
+              </target>
+            </configuration>
+          </execution>
+
+          <!-- package phase - attach artifact -->
+          <execution>
+            <id>package</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <target name="attach">
+                <attachartifact file="build/librocana-udfs.so" classifier="${os.detected.classifier}" type="so"/>
+              </target>
+            </configuration>
+          </execution>
+
+          <!-- clean phase - clean up any build artifacts -->
+          <execution>
+            <id>clean</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>clean</phase>
+            <configuration>
+              <target name="make-clean">
+                <exec executable="rm" failonerror="true">
+                   <arg value="-rf"/>
+                   <arg value="CMakeCache.txt"/>
+                   <arg value="CMakeFiles/"/>
+                   <arg value="Makefile"/>
+                   <arg value="cmake_install.cmake"/>
+                   <arg value="build"/>
+                </exec>
+              </target>
+            </configuration>
+          </execution>
+
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <distributionManagement>
+    <repository>
+      <id>com.rocana.releases</id>
+      <name>Rocana Release Repository</name>
+      <url>http://repository.rocana.com/content/repositories/com.scalingdata.releases/</url>
+    </repository>
+    <snapshotRepository>
+      <id>com.rocana.snapshots</id>
+      <name>Rocana Snapshots Repository</name>
+      <url>http://repository.rocana.com/content/repositories/com.scalingdata.snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <scm>
+    <connection>scm:git:git@github.com:scalingdata/rocana-impala-udfs.git</connection>
+    <url>https://github.com/scalingdata/rocana-impala-udfs</url>
+    <developerConnection>
+      scm:git:git@github.com:scalingdata/rocana-impala-udfs.git
+    </developerConnection>
+    <tag>master</tag>
+  </scm>
+
+</project>
+

--- a/rocana-release.sh
+++ b/rocana-release.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -x
+
+MVN=$(type -p mvn)
+MVN_FLAGS="-B"
+
+if [ -z "${ROCANA_IMPALA_UDFS_RELEASE_VERSION}" ] || [ -z "${ROCANA_IMPALA_UDFS_DEVELOPMENT_VERSION}" ]; then
+  echo "You must set ROCANA_IMPALA_UDFS_RELEASE_VERSION and ROCANA_IMPALA_UDFS_DEVELOPMENT_VERSION before running this script."
+  exit 1
+fi
+
+if [ -n "${WORKSPACE}" ]; then
+  MVN_FLAGS="${MVN_FLAGS} -f ${WORKSPACE}/pom.xml"
+  MVN_FLAGS="${MVN_FLAGS} -Dmaven.repo.local=${WORKSPACE}/.repository"
+fi
+
+error() {
+  local msg="$1"
+  local retcode="$2"
+
+  echo "Error: $msg"
+
+  [ -n "$retcode" ] && exit "$retcode"
+}
+
+# Set the version to the next release
+${MVN} ${MVN_FLAGS} \
+  versions:set \
+    -DnewVersion=${ROCANA_IMPALA_UDFS_RELEASE_VERSION} \
+    -DgenerateBackupPoms=false ||
+error "Unable to update the release version to ${ROCANA_IMPALA_UDFS_RELEASE_VERSION}" 1
+
+# Commit and push the version number update
+${MVN} ${MVN_FLAGS} \
+  scm:add \
+    -Dincludes=**/pom.xml \
+    -Dexcludes=**/target/**/pom.xml \
+  scm:checkin \
+    -Dmessage="ROCANA-BUILD: Preparing for release ${ROCANA_IMPALA_UDFS_RELEASE_VERSION}" ||
+error "Unable to checkin the update of the release version to ${ROCANA_IMPALA_UDFS_RELEASE_VERSION}" 1
+
+# Deploy the release to the maven repo
+${MVN} ${MVN_FLAGS} \
+  clean \
+  deploy ||
+error "Unable to deploy CDH artifacts to nexus" 1
+
+# Tag the release in git
+${MVN} ${MVN_FLAGS} \
+  scm:tag \
+    -Dtag=release-${ROCANA_IMPALA_UDFS_RELEASE_VERSION} ||
+error "Unable to create release tag" 1
+
+# Set the version to the next development version
+${MVN} ${MVN_FLAGS} \
+  versions:set \
+    -DnewVersion=${ROCANA_IMPALA_UDFS_DEVELOPMENT_VERSION} \
+    -DgenerateBackupPoms=false ||
+error "Unable to update the development version to ${ROCANA_IMPALA_UDFS_DEVELOPMENT_VERSION}" 1
+
+# Commit and push the version number update
+${MVN} ${MVN_FLAGS} \
+  scm:add \
+    -Dincludes=**/pom.xml \
+    -Dexcludes=**/target/**/pom.xml \
+  scm:checkin \
+    -Dmessage="ROCANA-BUILD: Preparing for ${ROCANA_IMPALA_UDFS_DEVELOPMENT_VERSION} development" ||
+error "Unable to checkin the update of the development version to ${ROCANA_IMPALA_UDFS_DEVELOPMENT_VERSION}" 1


### PR DESCRIPTION
This adds a pom file to wrap the cmake/make based build and a release script to perform a maven-based release process. This will be used to build and deploy the shared object file with the UDFs and I'll add a dependency in ROCANA-3693 to pull it into the packages.
